### PR TITLE
Parser: Fix unwrap with duration label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -143,13 +143,13 @@ JsonExpression {
 }
 
 DurationFilter {
-  DurationConv !eql Gtr Duration |
-  DurationConv !eql Gte Duration |
-  DurationConv !eql Lss Duration |
-  DurationConv !eql Lte Duration |
-  DurationConv !eql Neq Duration |
-  DurationConv !eql Eq Duration |
-  DurationConv !eql Eql Duration
+  Identifier !eql Gtr Duration |
+  Identifier !eql Gte Duration |
+  Identifier !eql Lss Duration |
+  Identifier !eql Lte Duration |
+  Identifier !eql Neq Duration |
+  Identifier !eql Eq Duration |
+  Identifier !eql Eql Duration
 }
 
 BytesFilter {
@@ -321,7 +321,7 @@ Range {
 UnwrapExpr {
   Pipe Unwrap Identifier |
   Pipe Unwrap ConvOp "("  Identifier ")" |
-  Unwrap Pipe LabelFilter
+  UnwrapExpr Pipe LabelFilter
 }
 
 Labels {
@@ -438,10 +438,7 @@ ConvOp {
   On,
   Ignoring,
   GroupLeft,
-  GroupRight,
-  BytesConv,
-  DurationConv,
-  DurationSecondsConv
+  GroupRight
 }
 
 @external extend {Identifier} extendIdentifier from "./tokens" {
@@ -476,6 +473,11 @@ QuantileOverTime { condFn<"quantile_over_time"> }
 FirstOverTime { condFn<"first_over_time"> }
 LastOverTime { condFn<"last_over_time"> }
 AbsentOverTime { condFn<"absent_over_time"> }
+
+// Conversion functions used with unwrap
+BytesConv { condFn<"bytes"> }
+DurationConv { condFn<"duration"> }
+DurationSecondsConv { condFn<"duration_seconds"> }
 
 
 // Conditional function names (only parsed as function names when used as such).

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -20,9 +20,6 @@ import {
     GroupLeft,
     GroupRight,
     Unwrap,
-    BytesConv,
-    DurationConv,
-    DurationSecondsConv,
     Sum,
     Avg,
     Count,
@@ -51,9 +48,6 @@ const keywordTokens = {
     group_left: GroupLeft,
     group_right: GroupRight,
     unwrap: Unwrap,
-    bytes: BytesConv,
-    duration: DurationConv,
-    duration_seconds: DurationSecondsConv
 };
 
 export const specializeIdentifier = (value, stack) => {

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -317,7 +317,7 @@ sum(sum_over_time({job="grafana"} |= "error" | logfmt | unwrap duration | __erro
 
 ==>
 
- LogQL(Expr(MetricExpr(VectorAggregationExpr(VectorOp(Sum), MetricExpr(RangeAggregationExpr(RangeOp(SumOverTime), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact), String)))), PipelineStage(Pipe, LabelParser(Logfmt))), UnwrapExpr(UnwrapExpr(Pipe, Unwrap, Identifier), Pipe, LabelFilter(Matcher(Identifier, Eq, String))), Range(Duration))))))))
+LogQL(Expr(MetricExpr(VectorAggregationExpr(VectorOp(Sum), MetricExpr(RangeAggregationExpr(RangeOp(SumOverTime), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact), String)))), PipelineStage(Pipe, LabelParser(Logfmt))), UnwrapExpr(UnwrapExpr(Pipe, Unwrap, Identifier), Pipe, LabelFilter(Matcher(Identifier, Eq, String))), Range(Duration))))))))
 
 
 # Metrics query with unwrap with duration as function
@@ -330,7 +330,7 @@ LogQL(Expr(MetricExpr(VectorAggregationExpr(VectorOp(Sum), MetricExpr(RangeAggre
 
 # Metrics query with unwrap with duration_seconds as function
 
-sum(sum_over_time({job="grafana"} |= "error" | logfmt | unwrap duration_seconds(label) | __error__="" [5m]))
+sum(sum_over_time({job="grafana"} |= "error" | logfmt | unwrap duration_seconds (label) | __error__="" [5m]))
 
 ==>
 

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -198,7 +198,7 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 
 ==>
 
-LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(Pipe, LabelParser(Logfmt))), PipelineStage(Pipe, LabelFilter(LabelFilter(UnitFilter(DurationFilter(DurationConv, Gtr, Duration))), And, LabelFilter(UnitFilter(BytesFilter(Identifier, Gtr, Bytes)))))))))
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(Pipe, LabelParser(Logfmt))), PipelineStage(Pipe, LabelFilter(LabelFilter(UnitFilter(DurationFilter(Identifier, Gtr, Duration))), And, LabelFilter(UnitFilter(BytesFilter(Identifier, Gtr, Bytes)))))))))
 
 # Complex log query with duration and bytes
 
@@ -206,15 +206,7 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 
 ==>
 
-LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(Pipe, LabelParser(Logfmt))), PipelineStage(Pipe, LabelFilter(LabelFilter(UnitFilter(DurationFilter(DurationConv, Gte, Duration))), Or, LabelFilter(LabelFilter(LabelFilter(Matcher(Identifier, Eq, String)), And, LabelFilter(UnitFilter(BytesFilter(Identifier, Lte, Bytes)))))))))))
-
-# Complex log query with duration and bytes
-
-{job="mysql"} | logfmt | duration >= 20ms or (method="GET" and size <= 20KB)
-
-==>
-
-LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(Pipe, LabelParser(Logfmt))), PipelineStage(Pipe, LabelFilter(LabelFilter(UnitFilter(DurationFilter(DurationConv, Gte, Duration))), Or, LabelFilter(LabelFilter(LabelFilter(Matcher(Identifier, Eq, String)), And, LabelFilter(UnitFilter(BytesFilter(Identifier, Lte, Bytes)))))))))))
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(Pipe, LabelParser(Logfmt))), PipelineStage(Pipe, LabelFilter(LabelFilter(UnitFilter(DurationFilter(Identifier, Gte, Duration))), Or, LabelFilter(LabelFilter(LabelFilter(Matcher(Identifier, Eq, String)), And, LabelFilter(UnitFilter(BytesFilter(Identifier, Lte, Bytes)))))))))))
 
 # Complex log query with parsing, filtering, label formatting and line formatting
 
@@ -251,7 +243,7 @@ sum by (host) (rate({job="mysql"} |= "error" != "timeout" | json | duration > 10
 
 ==>
 
-LogQL(Expr(MetricExpr(VectorAggregationExpr(VectorOp(Sum), Grouping(By, Labels(Identifier)), MetricExpr(RangeAggregationExpr(RangeOp(Rate), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact), String), LineFilter(Filter(Neq), String)))), PipelineStage(Pipe, LabelParser(Json))), PipelineStage(Pipe, LabelFilter(UnitFilter(DurationFilter(DurationConv, Gtr, Duration))))), Range(Duration))))))))
+LogQL(Expr(MetricExpr(VectorAggregationExpr(VectorOp(Sum), Grouping(By, Labels(Identifier)), MetricExpr(RangeAggregationExpr(RangeOp(Rate), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact), String), LineFilter(Filter(Neq), String)))), PipelineStage(Pipe, LabelParser(Json))), PipelineStage(Pipe, LabelFilter(UnitFilter(DurationFilter(Identifier, Gtr, Duration))))), Range(Duration))))))))
 
 # Vector aggregation query topk
 
@@ -318,3 +310,28 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matchers(Matcher(Identifier, Eq, String)), 
 ==>
 
 LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineExpr(PipelineExpr(PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact), String)))), PipelineStage(Pipe, LabelParser(Logfmt))), PipelineStage(Pipe, LineFormatExpr(LineFormat, String))), PipelineStage(Pipe, JsonExpressionParser(Json, JsonExpressionList(JsonExpression(Identifier, Eq, String))))), PipelineStage(Pipe, LineFormatExpr(LineFormat, String))))))
+
+# Metrics query with unwrap with duration as label
+
+sum(sum_over_time({job="grafana"} |= "error" | logfmt | unwrap duration | __error__="" [5m]))
+
+==>
+
+ LogQL(Expr(MetricExpr(VectorAggregationExpr(VectorOp(Sum), MetricExpr(RangeAggregationExpr(RangeOp(SumOverTime), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact), String)))), PipelineStage(Pipe, LabelParser(Logfmt))), UnwrapExpr(UnwrapExpr(Pipe, Unwrap, Identifier), Pipe, LabelFilter(Matcher(Identifier, Eq, String))), Range(Duration))))))))
+
+
+# Metrics query with unwrap with duration as function
+
+sum(sum_over_time({job="grafana"} |= "error" | logfmt | unwrap duration(label) | __error__="" [5m]))
+
+==>
+
+LogQL(Expr(MetricExpr(VectorAggregationExpr(VectorOp(Sum), MetricExpr(RangeAggregationExpr(RangeOp(SumOverTime), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact), String)))), PipelineStage(Pipe, LabelParser(Logfmt))), UnwrapExpr(UnwrapExpr(Pipe, Unwrap, ConvOp(DurationConv), Identifier), Pipe, LabelFilter(Matcher(Identifier, Eq, String))), Range(Duration))))))))
+
+# Metrics query with unwrap with duration_seconds as function
+
+sum(sum_over_time({job="grafana"} |= "error" | logfmt | unwrap duration_seconds(label) | __error__="" [5m]))
+
+==>
+
+LogQL(Expr(MetricExpr(VectorAggregationExpr(VectorOp(Sum), MetricExpr(RangeAggregationExpr(RangeOp(SumOverTime), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact), String)))), PipelineStage(Pipe, LabelParser(Logfmt))), UnwrapExpr(UnwrapExpr(Pipe, Unwrap, ConvOp(DurationSecondsConv), Identifier), Pipe, LabelFilter(Matcher(Identifier, Eq, String))), Range(Duration))))))))


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/49401

This PR:
1. In `DurationFilter` we need to use `Identifier` in the same way as it is used in https://github.com/grafana/loki/blob/main/pkg/logql/syntax/expr.y#L320
2. In `UnwrapExpr` the grammar should be `UnwrapExpr Pipe LabelFilter` instead of `Unwrap Pipe LabelFilter` as in https://github.com/grafana/loki/blob/main/pkg/logql/syntax/expr.y#L179
3. The conversion functions `duration`, `duration_seconds` and `bytes` are parsed only when used as functions.

I have also added and updated tests for these.