### PR TITLE
Grammar: Fix `LineFilters` to match multiple filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -53,7 +53,7 @@ Matcher {
 
 LineFilters {
   LineFilter | 
-  LineFilter LineFilter
+  LineFilters LineFilter
 }
 
 LineFilter {

--- a/tools/tree-viz.html
+++ b/tools/tree-viz.html
@@ -8,7 +8,7 @@
     <script type="importmap">
       {
         "imports": {
-          "@grafana/lezer-logql": "https://unpkg.com/@grafana/lezer-logql@0.0.11/index.es.js",
+          "@grafana/lezer-logql": "https://unpkg.com/@grafana/lezer-logql@0.0.13/index.es.js",
           "@lezer/lr": "https://unpkg.com/@lezer/lr@0.15.8/dist/index.js",
           "@lezer/common": "https://unpkg.com/@lezer/common@0.15.11/dist/index.js"
         }


### PR DESCRIPTION
The current grammar for `LineFilters` only matches two exact `LineFilter`, but I think it is supposed to match n-`LineFilter`.