### PR TITLE
switch js cdn

### DIFF
--- a/tools/tree-viz.html
+++ b/tools/tree-viz.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="https://unpkg.com/d3@6.7.0/dist/d3.min.js"></script>
-    <script src="https://unpkg.com/@hpcc-js/wasm@1.12.8/dist/index.min.js"></script>
-    <script src="https://unpkg.com/d3-graphviz@4.1.0/build/d3-graphviz.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/d3@6.7.0/dist/d3.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@hpcc-js/wasm@1.12.8/dist/index.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/d3-graphviz@4.1.0/build/d3-graphviz.min.js"></script>
 
     <script type="importmap">
       {
         "imports": {
-          "@grafana/lezer-logql": "https://unpkg.com/@grafana/lezer-logql@0.0.15/index.es.js",
-          "@lezer/lr": "https://unpkg.com/@lezer/lr@1.0.0/dist/index.js",
-          "@lezer/common": "https://unpkg.com/@lezer/common@1.0.0/dist/index.js"
+          "@grafana/lezer-logql": "https://cdn.jsdelivr.net/npm/@grafana/lezer-logql@0.0.15/index.es.js",
+          "@lezer/lr": "https://cdn.jsdelivr.net/npm/@lezer/lr@1.0.0/dist/index.js",
+          "@lezer/common": "https://cdn.jsdelivr.net/npm/@lezer/common@1.0.0/dist/index.js"
         }
       }
     </script>


### PR DESCRIPTION
the `tree-viz.html` example uses the `unpkg.com` javascript-cdn, but it is very slow.
i looked at the list of CDNs offered at https://yarnpkg.com/package/@lezer/common , and there was `jsDelivr`, and it seems to work a lot faster, so i switched to it.