### PR TITLE
Logql: Fix grammar for `String`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lezer-logql
 
-LogQL lezer grammar based on https://github.com/grafana/loki/blob/main/pkg/logql/expr.y.
+LogQL lezer grammar based on https://github.com/grafana/loki/blob/main/pkg/logql/syntax/expr.y.
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-logql",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -342,7 +342,7 @@ ConvOp {
   whitespace { std.whitespace+ }
   LineComment { "#" ![\n]* }
 
-  String { // TODO: This is for JS, make this work for LogQL.
+  String {
     '"' (![\\\n"] | "\\" _)* '"' |
     "`" ![`]* "`"
   }

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -343,8 +343,7 @@ ConvOp {
   LineComment { "#" ![\n]* }
 
   String { // TODO: This is for JS, make this work for LogQL.
-    '"' (![\\\n"] | "\\" _)* '"'? |
-    "'" (![\\\n'] | "\\" _)* "'"? |
+    '"' (![\\\n"] | "\\" _)* '"' |
     "`" ![`]* "`"
   }
 

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -87,6 +87,22 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier,Eq,String))),PipelineExp
 
 LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier,Eq,String))),PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact),String)))))))
 
+# Log query with pipe exact filter and unclosed quotes
+
+{job="loki"} |= "line
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact), ⚠, ⚠(Identifier))))))))
+
+# Log query with pipe exact filter and unclosed back-ticks
+
+{job="loki"} |= `line
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact), ⚠, ⚠(Identifier))))))))
+
 # Log query with pipe match line filter
 
 {job="loki"} |~ `error=\w+`

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -102,6 +102,21 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 ==>
 
 LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact), ⚠, ⚠(Identifier))))))))
+# Log query with pipe exact filter expression and escaped quotes
+
+{job="loki"} |= "hello\"quotes\""
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier,Eq,String))),PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact),String)))))))
+
+# Log query with pipe exact line filter expression and back-ticks and quotes
+
+{job="loki"} |= `hello"quotes"`
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier,Eq,String))),PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact),String)))))))
 
 # Log query with pipe match line filter
 

--- a/tools/tree-viz.html
+++ b/tools/tree-viz.html
@@ -8,7 +8,7 @@
     <script type="importmap">
       {
         "imports": {
-          "@grafana/lezer-logql": "https://cdn.jsdelivr.net/npm/@grafana/lezer-logql@0.0.15/index.es.js",
+          "@grafana/lezer-logql": "https://cdn.jsdelivr.net/npm/@grafana/lezer-logql@0.0.16/index.es.js",
           "@lezer/lr": "https://cdn.jsdelivr.net/npm/@lezer/lr@1.0.0/dist/index.js",
           "@lezer/common": "https://cdn.jsdelivr.net/npm/@lezer/common@1.0.0/dist/index.js"
         }


### PR DESCRIPTION
Currently our grammar has incorrectly matched string in 3 cases:
- If the string has single quotes `'`. This is not valid in LogQL.
- If the string with quotes `"` didn't have closing `"` (more info: https://discuss.codemirror.net/t/trying-to-understand-lezer-grammar-for-string/2264)
- If the string with back-tick \` didn't have closing \` (more info: https://discuss.codemirror.net/t/trying-to-understand-lezer-grammar-for-string/2264)

We are fixing this in this PR and adding tests.