### PR TITLE
Grammar: Add `DurationVariable`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-logql",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -315,7 +315,8 @@ OffsetExpr {
 }
 
 Range {
-  "[" Duration "]"
+  "[" Duration "]" |
+  "[" DurationVariable "]"
 }
 
 UnwrapExpr {
@@ -356,7 +357,7 @@ ConvOp {
     (std.asciiLetter | "_" | ":") (std.asciiLetter | std.digit | "_" | ":" )* 
   }
 
-    LabelName { (std.asciiLetter | "_") (std.asciiLetter | std.digit | "_")* }
+  LabelName { (std.asciiLetter | "_") (std.asciiLetter | std.digit | "_")* }
   
   Duration {
     // Each line below is just the same regex repeated over and over, but each time with one of the units made non-optional,
@@ -368,6 +369,11 @@ ConvOp {
     ( ( std.digit+ "y" )? ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" ) ( std.digit+ "s" )? ( std.digit+ "ms" )? ) |
     ( ( std.digit+ "y" )? ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" )? ( std.digit+ "s" ) ( std.digit+ "ms" )? ) |
     ( ( std.digit+ "y" )? ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" )? ( std.digit+ "s" )? ( std.digit+ "ms" ) )
+  }
+
+  DurationVariable {
+    '$__interval' | 
+    '$__interval_ms'
   }
   
   @precedence { Duration, Bytes, Number }

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -268,6 +268,22 @@ count_over_time({job="mysql"}[5m])
 
 LogQL(Expr(MetricExpr(RangeAggregationExpr(RangeOp(CountOverTime), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Range(Duration))))))
 
+# Count over time query with $__interval
+
+count_over_time({job="mysql"}[$__interval])
+
+==>
+
+LogQL(Expr(MetricExpr(RangeAggregationExpr(RangeOp(CountOverTime), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Range(DurationVariable))))))
+
+# Count over time query with $__interval_ms
+
+count_over_time({job="mysql"}[$__interval_ms])
+
+==>
+
+LogQL(Expr(MetricExpr(RangeAggregationExpr(RangeOp(CountOverTime), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Range(DurationVariable))))))
+
 # Complex aggregation query
 
 sum by (host) (rate({job="mysql"} |= "error" != "timeout" | json | duration > 10s [1m]))

--- a/tools/tree-viz.html
+++ b/tools/tree-viz.html
@@ -8,7 +8,7 @@
     <script type="importmap">
       {
         "imports": {
-          "@grafana/lezer-logql": "https://cdn.jsdelivr.net/npm/@grafana/lezer-logql@0.0.16/index.es.js",
+          "@grafana/lezer-logql": "https://cdn.jsdelivr.net/npm/@grafana/lezer-logql@0.0.17/index.es.js",
           "@lezer/lr": "https://cdn.jsdelivr.net/npm/@lezer/lr@1.0.0/dist/index.js",
           "@lezer/common": "https://cdn.jsdelivr.net/npm/@lezer/common@1.0.0/dist/index.js"
         }


### PR DESCRIPTION
As shown in this issue https://github.com/grafana/grafana/issues/54448 we are facing problems when parsing queries with errors. With the lezer-common update, lezer will not stop parsing until a known element is found or the end of the string. 

When parsing an empty stream selector `{}` followed by an unknown duration `[$__interval]` this resulted in unwanted behavior - e.g. when adding ad-hoc queries.

To overcome this for now, I added `$__interval` and `$__interval_ms` as known elements to the parser named as `DurationVariable`.