### PR TITLE
Chore: Upgrade the main package to `0.1.0`

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - v0.0.x
 
 jobs:
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-0.13.0 / 2022-06-17
+0.1.0 / 2022-06-17
+===================
+
+* **[Chore]**: Upgrade version to `0.1.0` to indicate the breaking change in a previous version.
+
+0.0.15 / 2022-06-17
 ===================
 
 * **[Chore]**: Upgrade `@lezer/lr` and `@lezer/generator` to their latest versions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.0.18",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-logql",
-      "version": "0.0.18",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.0.18",
+  "version": "0.1.0",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",


### PR DESCRIPTION
We decided to release version `0.1.0`. A version `0.0.19` will follow, which will break the compatibility with `0.1.x`.

Reasoning for this:
- The dependency `"@lezer/lr": "^1.0.0"`, which is used in version `0.1.0` of this plugin, is incompatible to versions before.