### PR TITLE
Grammar: Add `RateCounter`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-logql",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -219,6 +219,7 @@ LabelReplaceExpr {
 RangeOp {
   CountOverTime |
   Rate |
+  RateCounter |
   BytesOverTime |
   BytesRate |
   AvgOverTime |
@@ -460,6 +461,7 @@ ConvOp {
 // Range operations
 CountOverTime { condFn<"count_over_time"> }
 Rate { condFn<"rate"> }
+RateCounter { condFn<"rate_counter"> }
 BytesOverTime { condFn<"bytes_over_time"> }
 BytesRate { condFn<"bytes_rate"> }
 AvgOverTime { condFn<"avg_over_time"> }

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -268,6 +268,14 @@ count_over_time({job="mysql"}[5m])
 
 LogQL(Expr(MetricExpr(RangeAggregationExpr(RangeOp(CountOverTime), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Range(Duration))))))
 
+# Rate counter query on value inside log line
+
+sum(rate_counter({job="tns/app"} | logfmt | __error__=`` | unwrap label | __error__=`` [5m]))
+
+==>
+
+LogQL(Expr(MetricExpr(VectorAggregationExpr(VectorOp(Sum), MetricExpr(RangeAggregationExpr(RangeOp(RateCounter), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(Pipe, LabelParser(Logfmt))), PipelineStage(Pipe, LabelFilter(Matcher(Identifier, Eq, String)))), UnwrapExpr(UnwrapExpr(Pipe, Unwrap, Identifier), Pipe, LabelFilter(Matcher(Identifier, Eq, String))), Range(Duration))))))))
+
 # Complex aggregation query
 
 sum by (host) (rate({job="mysql"} |= "error" != "timeout" | json | duration > 10s [1m]))

--- a/tools/tree-viz.html
+++ b/tools/tree-viz.html
@@ -8,7 +8,7 @@
     <script type="importmap">
       {
         "imports": {
-          "@grafana/lezer-logql": "https://cdn.jsdelivr.net/npm/@grafana/lezer-logql@0.0.18/index.es.js",
+          "@grafana/lezer-logql": "https://cdn.jsdelivr.net/npm/@grafana/lezer-logql@0.1.1/index.es.js",
           "@lezer/lr": "https://cdn.jsdelivr.net/npm/@lezer/lr@1.0.0/dist/index.js",
           "@lezer/common": "https://cdn.jsdelivr.net/npm/@lezer/common@1.0.0/dist/index.js"
         }

--- a/tools/tree-viz.html
+++ b/tools/tree-viz.html
@@ -8,7 +8,7 @@
     <script type="importmap">
       {
         "imports": {
-          "@grafana/lezer-logql": "https://cdn.jsdelivr.net/npm/@grafana/lezer-logql@0.1.1/index.es.js",
+          "@grafana/lezer-logql": "https://cdn.jsdelivr.net/npm/@grafana/lezer-logql@latest/index.es.js",
           "@lezer/lr": "https://cdn.jsdelivr.net/npm/@lezer/lr@1.0.0/dist/index.js",
           "@lezer/common": "https://cdn.jsdelivr.net/npm/@lezer/common@1.0.0/dist/index.js"
         }


### PR DESCRIPTION
There is a new Range operation - rate_counter. This PR adds it into a grammar. https://grafana.com/docs/loki/latest/logql/metric_queries/#unwrapped-range-aggregations