### PR TITLE
Selector: Fix query being valid with incomplete matchers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-logql",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -21,8 +21,7 @@ LogExpr {
 }
 
 Selector {
-  "{" Matchers "}" |
-  "{" Matchers "," "}"
+  "{" Matchers "}"
 }
 
 PipelineExpr {

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -389,3 +389,11 @@ LogQL(Expr(MetricExpr(VectorAggregationExpr(VectorOp(Sum), MetricExpr(RangeAggre
 ==>
 
 LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeExact), String)))), PipelineStage(Pipe, JsonExpressionParser(Json, JsonExpressionList(JsonExpressionList(JsonExpressionList(JsonExpression(Identifier, Eq, String)), JsonExpression(Identifier, Eq, String)), JsonExpression(Identifier, Eq, String))))))))
+
+# Simple log query with back-ticks and comma to have error
+
+{job="loki",}
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matchers(Matcher(Identifier, Eq, String)), ⚠)))))


### PR DESCRIPTION
Discovered in https://github.com/grafana/grafana/pull/65287 a query like `{label="value",}` would currently be considered valid. With this PR this is fixed.

`Matchers` can already contain `,`, so it's enough to remove `"{" Matchers "," "}"`.