### PR TITLE
Grammar: add distinct filter support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-logql",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -40,7 +40,8 @@ PipelineStage {
   Pipe JsonExpressionParser |
   Pipe LabelFilter |
   Pipe LineFormatExpr |
-  Pipe LabelFormatExpr
+  Pipe LabelFormatExpr |
+  Pipe DistinctFilter
 }
 
 Matcher {
@@ -83,6 +84,10 @@ JsonExpressionParser {
   Json JsonExpressionList
 }
 
+DistinctFilter {
+  Distinct DistinctFilterList
+}
+
 LabelFilter {
   Matcher |
   IpLabelFilter |
@@ -105,6 +110,11 @@ LabelFormatExpr {
 JsonExpressionList {
   JsonExpression |
   JsonExpressionList !and "," JsonExpression
+}
+
+DistinctFilterList {
+  Identifier |
+  DistinctFilterList !and "," Identifier
 }
 
 IpLabelFilter {
@@ -443,7 +453,8 @@ ConvOp {
   On,
   Ignoring,
   GroupLeft,
-  GroupRight
+  GroupRight,
+  Distinct
 }
 
 @external extend {Identifier} extendIdentifier from "./tokens" {

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -85,7 +85,7 @@ JsonExpressionParser {
 }
 
 DistinctFilter {
-  Distinct DistinctFilterList
+  Distinct DistinctLabel
 }
 
 LabelFilter {
@@ -112,9 +112,9 @@ JsonExpressionList {
   JsonExpressionList !and "," JsonExpression
 }
 
-DistinctFilterList {
+DistinctLabel {
   Identifier |
-  DistinctFilterList !and "," Identifier
+  DistinctLabel !and "," Identifier
 }
 
 IpLabelFilter {

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -29,7 +29,8 @@ import {
     Stddev,
     Stdvar,
     Bottomk,
-    Topk
+    Topk,
+    Distinct
 } from './parser.terms.js';
 
 const keywordTokens = {
@@ -50,6 +51,7 @@ const keywordTokens = {
     group_left: GroupLeft,
     group_right: GroupRight,
     unwrap: Unwrap,
+    distinct: Distinct,
 };
 
 export const specializeIdentifier = (value, stack) => {

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -404,7 +404,7 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matchers(Matcher(Identifier, Eq, String)), 
 
 ==>
 
-LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(Pipe, DistinctFilter(Distinct, DistinctFilterList(Identifier)))))))
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(Pipe, DistinctFilter(Distinct, DistinctLabel(Identifier)))))))
 
 # Log query with distinct filter with many fields
 
@@ -412,7 +412,7 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 
 ==>
 
-LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(Pipe, DistinctFilter(Distinct, DistinctFilterList(DistinctFilterList(Identifier), Identifier)))))))
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(Pipe, DistinctFilter(Distinct, DistinctLabel(DistinctLabel(Identifier), Identifier)))))))
 
 # Log query with parser and distinct filter with many fields
 
@@ -420,4 +420,4 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 
 ==>
 
-LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(Pipe, LabelParser(Json))), PipelineStage(Pipe, DistinctFilter(Distinct, DistinctFilterList(DistinctFilterList(Identifier), Identifier)))))))
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(Pipe, LabelParser(Json))), PipelineStage(Pipe, DistinctFilter(Distinct, DistinctLabel(DistinctLabel(Identifier), Identifier)))))))

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -397,3 +397,27 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 ==>
 
 LogQL(Expr(LogExpr(Selector(Matchers(Matchers(Matcher(Identifier, Eq, String)), ⚠)))))
+
+# Log query with distinct filter one field
+
+{job="loki"} | distinct id
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(Pipe, DistinctFilter(Distinct, DistinctFilterList(Identifier)))))))
+
+# Log query with distinct filter with many fields
+
+{job="loki"} | distinct id, email
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(Pipe, DistinctFilter(Distinct, DistinctFilterList(DistinctFilterList(Identifier), Identifier)))))))
+
+# Log query with parser and distinct filter with many fields
+
+{job="loki"} | json | distinct id, email
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(Pipe, LabelParser(Json))), PipelineStage(Pipe, DistinctFilter(Distinct, DistinctFilterList(DistinctFilterList(Identifier), Identifier)))))))


### PR DESCRIPTION
This PR adds support to the DISTINCT filter expression added in https://github.com/grafana/loki/pull/8662

Examples:

```
{app="order"} | json | distinct id
```

```
{app="order"} | json | distinct id, time
```

Generated tree:

![imagen](https://github.com/grafana/lezer-logql/assets/1069378/bbace083-8697-4e00-956a-2ebf6cf83a9e)

Part of https://github.com/grafana/grafana/issues/68170
