### PR TITLE
allow multiline queries

### DIFF
--- a/tools/tree-viz.html
+++ b/tools/tree-viz.html
@@ -17,34 +17,33 @@
 
     <style>
       #out > svg {
-        position: fixed;
-        left: 0;
-        top: 35px;
-        max-width: 100%;
-        max-height: 100%;
+        width: 100%;
+        height: 100vh;
       }
     </style>
   </head>
   <body>
-    <input style="width: 100%" id="in" type="text" value='count_over_time({level="info"}[10s])' />
+    <textarea style="width: 100%; resize: vertical" id="in" type="text">
+count_over_time({level="info"}[10s])</textarea
+    >
     <div id="cursor-pos"></div>
     <div id="out"></div>
     <script type="module">
-      import('@grafana/lezer-logql').then(
+      import("@grafana/lezer-logql").then(
         (lezerLogQL) => {
-          const inElem = document.querySelector('#in');
-          const cursorPosElem = document.querySelector('#cursor-pos');
+          const inElem = document.querySelector("#in");
+          const cursorPosElem = document.querySelector("#cursor-pos");
 
-          let currentlyVisualizedText = '';
+          let currentlyVisualizedText = "";
           let currentlyVisualizedPos = 0;
 
-          const graphViz = d3.select('#out').graphviz();
+          const graphViz = d3.select("#out").graphviz();
 
           inElem.focus();
           inElem.setSelectionRange(25, 25);
 
           function getNodeText(node) {
-            const prefix = node.type.isError ? 'ERROR' : node.name;
+            const prefix = node.type.isError ? "ERROR" : node.name;
             return `${prefix}_${node.index}__${node.from}_${node.to}`;
           }
 
@@ -60,7 +59,10 @@
             const text = inElem.value;
             const pos = inElem.selectionStart;
 
-            if (text === currentlyVisualizedText && pos === currentlyVisualizedPos) {
+            if (
+              text === currentlyVisualizedText &&
+              pos === currentlyVisualizedPos
+            ) {
               // no changes
               return;
             }
@@ -78,7 +80,7 @@
             const nodeText = getNodeText(tree.cursor(pos));
 
             const graphText = `digraph {
-              ${graphLines.join('\n')}
+              ${graphLines.join("\n")}
               ${nodeText} [style=filled]
             }`.trim();
 
@@ -92,11 +94,13 @@
 
           render();
 
-          inElem.addEventListener('keyup', render);
-          inElem.addEventListener('click', render);
+          inElem.addEventListener("keyup", render);
+          inElem.addEventListener("click", render);
         },
         (error) => {
-          window.alert('module import failed. this requires a browser with import map support.');
+          window.alert(
+            "module import failed. this requires a browser with import map support."
+          );
           console.error(error);
         }
       );


### PR DESCRIPTION
when visualising larger queries, it can be hard to refer back to the inputted query when its all condensed onto one line. this pr allows you to resize the query input.

Before and After:
<img width="1728" alt="Screenshot 2023-06-01 at 15 42 42" src="https://github.com/grafana/lezer-logql/assets/34524710/4f585be7-756a-4713-bb0c-291e3eaac289">

<img width="1728" alt="Screenshot 2023-06-01 at 15 42 18" src="https://github.com/grafana/lezer-logql/assets/34524710/fe0b02d7-8a54-4be2-a505-d7fe318190b6">
