### PR TITLE
LogRangeExpr: Fix incorrect offset node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-logql",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -261,7 +261,7 @@ LogRangeExpr {
   Selector Range UnwrapExpr |
   Selector Range OffsetExpr UnwrapExpr |
   "(" Selector ")" Range UnwrapExpr |
-  "(" Selector ")" Range Offset UnwrapExpr |
+  "(" Selector ")" Range OffsetExpr UnwrapExpr |
   Selector UnwrapExpr Range |
   Selector UnwrapExpr Range OffsetExpr |
   "(" Selector UnwrapExpr ")" Range |

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -437,3 +437,11 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 ==>
 
 LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineExpr(PipelineStage(Pipe, LabelParser(Logfmt))), PipelineStage(Pipe, LabelFilter(Matcher(Identifier, Eq, String)))), PipelineStage(Pipe, DecolorizeExpr(Decolorize))))))
+
+# Range aggregation expression - "(" Selector ")" Range OffsetExpr UnwrapExpr
+
+rate(({label=""}) [1s] offset 1h | unwrap label)
+
+==>
+
+LogQL(Expr(MetricExpr(RangeAggregationExpr(RangeOp(Rate), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Range(Duration), OffsetExpr(Offset, Duration), UnwrapExpr(Pipe, Unwrap, Identifier))))))


### PR DESCRIPTION
replace `Offset` with `OffsetExpr`.
lezer was expecting the wrong node therefore throwing errors with valid queries.

**Before & After:**

<img width="1713" alt="Screenshot 2023-07-06 at 10 55 48" src="https://github.com/grafana/lezer-logql/assets/34524710/8467f29a-f1df-4cff-9c9d-db21fd82f2a4">
<img width="1711" alt="Screenshot 2023-07-06 at 10 56 19" src="https://github.com/grafana/lezer-logql/assets/34524710/332244bd-df4c-492c-97de-cd5bb6b48e6a">
