### PR TITLE
Include cjs and mjs in formatting

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,3 +1,3 @@
 module.exports = {
-    presets: [['@babel/preset-env', {targets: {node: 'current'}}]],
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
 };

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -24,7 +24,7 @@ const config = {
   // collectCoverageFrom: undefined,
 
   // The directory where Jest should output its coverage files
-  coverageDirectory: "coverage",
+  coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
   // coveragePathIgnorePatterns: [
@@ -32,7 +32,7 @@ const config = {
   // ],
 
   // Indicates which provider should be used to instrument code for coverage
-  coverageProvider: "v8",
+  coverageProvider: 'v8',
 
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "rollup": "^2.27.1"
   },
   "lint-staged": {
-    "**/*.js": [
+    "**/*.{js,cjs,mjs}": [
       "eslint --fix",
       "prettier --write"
     ],


### PR DESCRIPTION
also include other js filetypes in formatting and linting with prettier/eslint.

added:
- `.cjs`
- `.js`