### PR TITLE
Fix npm publish workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest",
     "build:test": "npm run build && npm run test",
     "pre-commit": "lint-staged",
-    "prepare": "husky install"
+    "prepare": "test -d node_modules/husky && husky install"
   },
   "devDependencies": {
     "@babel/core": "^7.22.8",


### PR DESCRIPTION
the **publish-npm** workflow is failing with `sh: 1: husky: not found`.
this is because husky is a dev dependency but the workflow only installs production dependencies.

this workaround stems from the following: https://github.com/typicode/husky/issues/914#issuecomment-1376981862

how this works:
- if husky exists in node_modules then we can run the scrip and it wont fail.
- if it doesn't exist (package not installed) we do nothing.