### PR TITLE
Fix npm publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,11 +35,11 @@ jobs:
 
       - name: Install dependencies
         if: steps.version_check.outputs.changed == 'true'
-        run: yarn
+        run: npm install --ignore-scripts
 
       - name: Build library
         if: steps.version_check.outputs.changed == 'true'
-        run: yarn build
+        run: npm run build
 
       - name: Publish package to NPM
         if: steps.version_check.outputs.changed == 'true'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest",
     "build:test": "npm run build && npm run test",
     "pre-commit": "lint-staged",
-    "prepare": "test -d node_modules/husky && husky install || echo 'husky not installed... ignoring script'"
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@babel/core": "^7.22.8",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest",
     "build:test": "npm run build && npm run test",
     "pre-commit": "lint-staged",
-    "prepare": "test -d node_modules/husky && husky install"
+    "prepare": "test -d node_modules/husky && husky install || echo 'husky not installed... ignoring script'"
   },
   "devDependencies": {
     "@babel/core": "^7.22.8",


### PR DESCRIPTION
due to an oversight on my behalf, (https://github.com/grafana/lezer-logql/pull/34) didn't actually fix the issue.

as you can see from the demo, without the second half of the script, if husky doesn't exist it still throws an error making the workflow fail. however, with the second half, if husky doesn't exist the command just runs `echo` and doesn't error

github is now throwing errors whilst trying to upload the demo (linked in slack thread):

https://raintank-corp.slack.com/archives/C03PMJLVC67/p1689594553023209?thread_ts=1689588697.351199&cid=C03PMJLVC67