### PR TITLE
Revert "Bump package version"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.7",
+  "version": "0.1.6",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.8",
+  "version": "0.1.7",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",


### PR DESCRIPTION
Reverts grafana/lezer-logql#36

this bump was to trigger the workflow which still failed to publish, we can revert this so we don't skip many unnecessary versions.