### PR TITLE
Replace prepare script with postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.8",
+  "version": "0.1.7",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest",
     "build:test": "npm run build && npm run test",
     "pre-commit": "lint-staged",
-    "prepare": "husky install"
+    "postinstall": "husky install"
   },
   "devDependencies": {
     "@babel/core": "^7.22.8",


### PR DESCRIPTION
> first we merge #37 to revert back to 0.1.6, we then merge this that will build and release to 0.1.7

the issue we had was `prepare` we being called in the background of `npm publish...` this was then making the workflow fail because husky was not installed.

this changes the script to `postinstall` that still runs after `npn install` but doesnt get triggerd in the build and publish workflow

https://docs.npmjs.com/cli/v9/using-npm/scripts#npm-install