### PR TITLE
Fix husky error when installing lezer-logql as dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",
@@ -17,7 +17,7 @@
     "test": "jest",
     "build:test": "npm run build && npm run test",
     "pre-commit": "lint-staged",
-    "postinstall": "husky install"
+    "prepare": "node_modules/.bin/husky install"
   },
   "devDependencies": {
     "@babel/core": "^7.22.8",


### PR DESCRIPTION
> we only want to merge this after #39 so that fix is also included in the build

currently if you try to install `@grafana/lezer-logql@0.1.7` you will receive an error. this is caused by using "postinstall" instead of "prepare".
`One word of caution, use the "postinstall" hook only if you're not publishing your project on npm, else your users will get errors when trying to install your module.` https://github.com/typicode/husky/issues/227#issuecomment-361779926