### PR TITLE
Remove husky pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npm run pre-commit

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@rollup/plugin-node-resolve": "15.1.0",
         "babel-jest": "^29.6.1",
         "eslint": "^8.44.0",
-        "husky": "^8.0.3",
         "jest": "^29.6.1",
         "lint-staged": "^13.2.3",
         "prettier": "^3.0.0",
@@ -4106,21 +4105,6 @@
       "dev": true,
       "engines": {
         "node": ">=14.18.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {
@@ -9740,12 +9724,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
       "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
-      "dev": true
-    },
-    "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true
     },
     "ignore": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "build": "bash ./build.sh",
     "test": "jest",
     "build:test": "npm run build && npm run test",
-    "pre-commit": "lint-staged",
-    "prepare": "node_modules/.bin/husky install"
+    "pre-commit": "lint-staged"
   },
   "devDependencies": {
     "@babel/core": "^7.22.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@rollup/plugin-node-resolve": "15.1.0",
     "babel-jest": "^29.6.1",
     "eslint": "^8.44.0",
-    "husky": "^8.0.3",
     "jest": "^29.6.1",
     "lint-staged": "^13.2.3",
     "prettier": "^3.0.0",


### PR DESCRIPTION
husky was causing many problems when it comes to releasing a new version of lezer-logql.
our last plan was to just remove it so we can release a new version an be unblocked.