### PR TITLE
Grammar: Add `drop` and `keep` operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-logql",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -42,7 +42,8 @@ PipelineStage {
   Pipe LineFormatExpr |
   Pipe LabelFormatExpr |
   Pipe DistinctFilter |
-  Pipe DecolorizeExpr
+  Pipe DecolorizeExpr |
+  Pipe DropLabelsExpr
 }
 
 Matcher {
@@ -110,6 +111,20 @@ LabelFormatExpr {
 
 DecolorizeExpr {
   Decolorize
+}
+
+DropLabel {
+  Identifier |
+  Matcher
+}
+
+DropLabels {
+  DropLabel |
+  DropLabels !and "," DropLabel
+}
+
+DropLabelsExpr {
+  Drop DropLabels
 }
 
 JsonExpressionList {
@@ -460,7 +475,8 @@ ConvOp {
   GroupLeft,
   GroupRight,
   Distinct,
-  Decolorize
+  Decolorize,
+  Drop
 }
 
 @external extend {Identifier} extendIdentifier from "./tokens" {

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -43,7 +43,8 @@ PipelineStage {
   Pipe LabelFormatExpr |
   Pipe DistinctFilter |
   Pipe DecolorizeExpr |
-  Pipe DropLabelsExpr
+  Pipe DropLabelsExpr |
+  Pipe KeepLabelsExpr
 }
 
 Matcher {
@@ -125,6 +126,20 @@ DropLabels {
 
 DropLabelsExpr {
   Drop DropLabels
+}
+
+KeepLabel {
+  Identifier |
+  Matcher
+}
+
+KeepLabels {
+  KeepLabel |
+  KeepLabels !and "," KeepLabel
+}
+
+KeepLabelsExpr {
+  Keep KeepLabels
 }
 
 JsonExpressionList {
@@ -476,7 +491,8 @@ ConvOp {
   GroupRight,
   Distinct,
   Decolorize,
-  Drop
+  Drop,
+  Keep
 }
 
 @external extend {Identifier} extendIdentifier from "./tokens" {

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -32,6 +32,7 @@ import {
   Topk,
   Distinct,
   Decolorize,
+  Drop,
 } from './parser.terms.js';
 
 const keywordTokens = {
@@ -54,6 +55,7 @@ const keywordTokens = {
   unwrap: Unwrap,
   distinct: Distinct,
   decolorize: Decolorize,
+  drop: Drop,
 };
 
 export const specializeIdentifier = (value) => {

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -33,6 +33,7 @@ import {
   Distinct,
   Decolorize,
   Drop,
+  Keep,
 } from './parser.terms.js';
 
 const keywordTokens = {
@@ -56,6 +57,7 @@ const keywordTokens = {
   distinct: Distinct,
   decolorize: Decolorize,
   drop: Drop,
+  keep: Keep,
 };
 
 export const specializeIdentifier = (value) => {

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -461,3 +461,19 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 ==>
 
 LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(Pipe, DropLabelsExpr(Drop, DropLabels(DropLabels(DropLabels(DropLabel(Identifier)), DropLabel(Identifier)), DropLabel(Matcher(Identifier, Eq, String)))))))))
+
+# Keep with one label
+
+{label=""} | keep name
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(Pipe, KeepLabelsExpr(Keep, KeepLabels(KeepLabel(Identifier))))))))
+
+# Keep with multiple labels and matchers
+
+{label=""} | keep name, other_name, some_name="some_value"
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(Pipe, KeepLabelsExpr(Keep, KeepLabels(KeepLabels(KeepLabels(KeepLabel(Identifier)), KeepLabel(Identifier)), KeepLabel(Matcher(Identifier, Eq, String)))))))))

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -445,3 +445,19 @@ rate(({label=""}) [1s] offset 1h | unwrap label)
 ==>
 
 LogQL(Expr(MetricExpr(RangeAggregationExpr(RangeOp(Rate), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Range(Duration), OffsetExpr(Offset, Duration), UnwrapExpr(Pipe, Unwrap, Identifier))))))
+
+# Drop with one label
+
+{label=""} | drop name
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(Pipe, DropLabelsExpr(Drop, DropLabels(DropLabel(Identifier))))))))
+
+# Drop with multiple labels and matchers
+
+{label=""} | drop name, other_name, some_name="some_value"
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(Pipe, DropLabelsExpr(Drop, DropLabels(DropLabels(DropLabels(DropLabel(Identifier)), DropLabel(Identifier)), DropLabel(Matcher(Identifier, Eq, String)))))))))


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/70187 

While working on `drop` I noticed that in [LogQL grammar](https://github.com/grafana/loki/blob/main/pkg/logql/syntax/expr.y) another similar operations was added - `keep` so I implemented both. 

It follows the same grammar patterns as https://github.com/grafana/loki/blob/main/pkg/logql/syntax/expr.y. 
