### PR TITLE
LogQL: add sort and sort_desc support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 0.1.0 / 2023-09-05
+# 0.2.1 / 2023-10-17
+
+- **[Chore]**: Upgrade version to `0.2.1`. Added support for `sort()` and `sort_desc()`.
+
+# 0.2.0 / 2023-08-26
 
 - **[Chore]**: Upgrade version to `0.2.0`. Breaking changes: Logfmt now supports flags (--strict, --keep-empty) and arguments (labels), so Logfmt nodes are no longer `LabelParser` and will generate `LogfmtParser` and `LogfmtExpressionParser` nodes.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-logql",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.22.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -324,7 +324,9 @@ VectorOp {
   Stddev |
   Stdvar |
   Bottomk |
-  Topk
+  Topk |
+  Sort |
+  Sort_Desc
 }
 
 
@@ -519,7 +521,9 @@ ConvOp {
   Stddev,
   Stdvar,
   Bottomk,
-  Topk
+  Topk,
+  Sort,
+  Sort_Desc
 }
 
 // Range operations

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -33,6 +33,8 @@ import {
   Decolorize,
   Drop,
   Keep,
+  Sort,
+  Sort_Desc,
 } from './parser.terms.js';
 
 const keywordTokens = {
@@ -77,6 +79,8 @@ const contextualKeywordTokens = {
   stdvar: Stdvar,
   bottomk: Bottomk,
   topk: Topk,
+  sort: Sort,
+  sort_desc: Sort_Desc,
 };
 
 export const extendIdentifier = (value) => {

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -477,3 +477,19 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 ==>
 
 LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(Pipe, KeepLabelsExpr(Keep, KeepLabels(KeepLabels(KeepLabels(KeepLabel(Identifier)), KeepLabel(Identifier)), KeepLabel(Matcher(Identifier, Eq, String)))))))))
+
+# Sort
+
+sort(rate(({app=~"foo|bar"} |~".+bar")[1m])) without (app)  
+
+==> 
+
+LogQL(Expr(MetricExpr(VectorAggregationExpr(VectorOp(Sort), MetricExpr(RangeAggregationExpr(RangeOp(Rate), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Re, String))), PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipeMatch), String)))), Range(Duration)))), Grouping(Without, Labels(Identifier))))))
+
+# Sort desc
+
+sort_desc(sum(count_over_time({namespace=~".+"}[1m])) by (namespace))
+
+==>
+
+LogQL(Expr(MetricExpr(VectorAggregationExpr(VectorOp(Sort_Desc), MetricExpr(VectorAggregationExpr(VectorOp(Sum), MetricExpr(RangeAggregationExpr(RangeOp(CountOverTime), LogRangeExpr(Selector(Matchers(Matcher(Identifier, Re, String))), Range(Duration)))), Grouping(By, Labels(Identifier))))))))


### PR DESCRIPTION
Adding support to `sort` and `sort_desc` for proper query handling, validation, and syntax highlighting.

Reference: https://github.com/grafana/loki/blob/main/pkg/logql/syntax/expr.y

LogQL part of https://github.com/grafana/grafana/issues/70882

Trees before:

![Before 1](https://github.com/grafana/lezer-logql/assets/1069378/e078f089-2e98-4fe8-a0a0-876a67cfa316)

![Before 2](https://github.com/grafana/lezer-logql/assets/1069378/4a06b49b-58a4-4ec9-8c8c-80cc74286bf8)

Trees after:

![After 2](https://github.com/grafana/lezer-logql/assets/1069378/9d4d60c3-2753-4199-b64b-5306745e5c9d)

![After 1](https://github.com/grafana/lezer-logql/assets/1069378/d29d0ee3-0238-4c01-832f-98c4823ae1a2)

