### PR TITLE
Fix: exports must declare types for node16+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@lezer/lr": "^1.0.0"
   },
   "exports": {
+    "types": "./index.d.ts",
     "import": "./index.es.js",
     "require": "./index.cjs"
   },


### PR DESCRIPTION
Packages that declare themselves as ES modules (`"type": "module"` in package.json) that also include an `exports` property must declare a `types` property otherwise Typescript cannot find the types when typescripts `"moduleResolution": "bundler"` is set. Checking against [are the types wrong](https://arethetypeswrong.github.io/?p=%40grafana%2Flezer-logql%400.2.4) asserts that types cannot be found for anything above node10. An example of the error can be seen below:

![image](https://github.com/grafana/lezer-logql/assets/73201/e7d58530-92db-40c5-862f-3f9412cf2df4)
