### PR TITLE
feat: Support negative numbers in LogQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.4 / 2023-06-03
+
+- **[Chore]**: Upgrade version to `0.2.4`. Added support for negative numbers.
+
 # 0.2.3 / 2023-11-24
 
 - **[Chore]**: Upgrade version to `0.2.3`. Fix allowing the use of `ip` as a label name and correctly parse queries with it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/formatter/logs.js
+++ b/src/formatter/logs.js
@@ -21,7 +21,7 @@ import {
   BytesFilter,
   Duration,
   Bytes,
-  Number,
+  LiteralExpr,
   LabelFormatMatcher,
   FilterOp,
   DecolorizeExpr,
@@ -241,7 +241,7 @@ export function formatLabelFilter(node, query) {
   } else if (selectedFilterType === BytesFilter) {
     valueNode = selectedFilter.getChild(Bytes);
   } else if (selectedFilterType === NumberFilter) {
-    valueNode = selectedFilter.getChild(Number);
+    valueNode = selectedFilter.getChild(LiteralExpr);
   } else {
     valueNode = selectedFilter.getChild(String);
   }

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -177,13 +177,13 @@ UnitFilter {
 }
 
 NumberFilter {
-  Identifier !eql Gtr Number |
-  Identifier !eql Gte Number |
-  Identifier !eql Lss Number |
-  Identifier !eql Lte Number |
-  Identifier !eql Neq Number |
-  Identifier !eql Eq Number |
-  Identifier !eql Eql Number
+  Identifier !eql Gtr LiteralExpr |
+  Identifier !eql Gte LiteralExpr |
+  Identifier !eql Lss LiteralExpr |
+  Identifier !eql Lte LiteralExpr |
+  Identifier !eql Neq LiteralExpr |
+  Identifier !eql Eq LiteralExpr |
+  Identifier !eql Eql LiteralExpr
 }
 
 LabelsFormat {

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -544,3 +544,11 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 ==>
 
 LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(Pipe, LogfmtParser(Logfmt))), PipelineStage(Pipe, LabelFilter(IpLabelFilter(Identifier, Eq, Ip, String)))))))
+
+# Log query with negative numbers
+
+{foo="bar"} | logfmt | counter>-1 | counter>=-1 | counter<-1 | counter<=-1 | counter!=-1 | counter==-1
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineExpr(PipelineExpr(PipelineExpr(PipelineExpr(PipelineExpr(PipelineStage(Pipe, LogfmtParser(Logfmt))), PipelineStage(Pipe, LabelFilter(NumberFilter(Identifier, Gtr, LiteralExpr(Sub, Number))))), PipelineStage(Pipe, LabelFilter(NumberFilter(Identifier, Gte, LiteralExpr(Sub, Number))))), PipelineStage(Pipe, LabelFilter(NumberFilter(Identifier, Lss, LiteralExpr(Sub, Number))))), PipelineStage(Pipe, LabelFilter(NumberFilter(Identifier, Lte, LiteralExpr(Sub, Number))))), PipelineStage(Pipe, LabelFilter(NumberFilter(Identifier, Neq, LiteralExpr(Sub, Number))))), PipelineStage(Pipe, LabelFilter(NumberFilter(Identifier, Eql, LiteralExpr(Sub, Number))))))))

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -18,7 +18,6 @@ import {
   LiteralExpr,
   LabelReplaceExpr,
   VectorExpr,
-  LabelParser,
 } from '../src/parser';
 import {
   formatSelector,


### PR DESCRIPTION
Mirrors https://github.com/grafana/loki/pull/13091

Adds negative number support to the LogQL parser.

* Works for both ints and floats.
* Negative durations are already supported.
* Negative bytes are not supported because the humanize library does not support them 

![Tree](https://github.com/grafana/lezer-logql/assets/1069378/22a05dbf-6759-4568-98b3-3476d3484704)