### PR TITLE
Add support for pattern match/not-match line filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.6 / 2023-06-03
+
+- **[Chore]**: Upgrade version to `0.2.6`. Added support for pattern match/not-match line filters.
+
 # 0.2.4 / 2023-06-03
 
 - **[Chore]**: Upgrade version to `0.2.4`. Added support for negative numbers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.2.3",
+  "version": "0.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-logql",
-      "version": "0.2.3",
+      "version": "0.2.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.22.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -76,6 +76,8 @@ LineFilter {
 Filter {
   !eql PipeExact |
   !eql PipeMatch |
+  !eql PipePattern |
+  !eql Npa |
   !eql Nre |
   !eql Neq
 }
@@ -484,6 +486,8 @@ ConvOp {
   Eql  { "==" }
   PipeExact { "|=" }
   PipeMatch { "|~" }
+  PipePattern { "|>" }
+  Npa { "!>" }
   Add { "+" }
   Mul { "*" }
   Mod { "%" }

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -150,6 +150,21 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier,Eq,String))),PipelineExp
 
 LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(LineFilters(LineFilters(LineFilter(Filter(PipeExact), String)), LineFilter(Filter(Nre), String)))))))
 
+# Log query with pipe match pattern line filter
+
+{job="loki"} |> "hello"
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier,Eq,String))),PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipePattern),String)))))))
+
+# Log query with pipe not match pattern line filter
+
+{job="loki"} !> "hello"
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier,Eq,String))),PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(Npa),String)))))))
 
 # Log query with logfmt parser
 

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -156,7 +156,7 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 
 ==>
 
-LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier,Eq,String))),PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipePattern),String)))))))
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(PipePattern), String)))))))
 
 # Log query with pipe not match pattern line filter
 
@@ -164,7 +164,7 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier,Eq,String))),PipelineExp
 
 ==>
 
-LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier,Eq,String))),PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(Npa),String)))))))
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineStage(LineFilters(LineFilter(Filter(Npa), String)))))))
 
 # Log query with logfmt parser
 


### PR DESCRIPTION
Enables support for parsing LogQL expression with pattern match line filters such as:

```
{ app="foobar" }  |> "I <_>"| json
```

and

```
{ app="foobar" }  !> "I <_>"| json
```