### PR TITLE
fix: allow floats to be used as duration and bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.7 / 2025-01-16
+
+- **[Chore]**: Upgrade version to `0.2.7`. Added support for floats to be used in `Duration` and `Bytes`.
+- 
 # 0.2.6 / 2023-06-03
 
 - **[Chore]**: Upgrade version to `0.2.6`. Added support for pattern match/not-match line filters.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-logql",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.22.8",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "bash ./build.sh",
     "test": "jest",
     "build:test": "npm run build && npm run test",
-    "pre-commit": "lint-staged"
+    "pre-commit": "lint-staged",
+    "local": "python -m http.server & SERVER_PID=$! && trap 'kill $SERVER_PID' INT && open http://localhost:8000/tools/tree-viz.local.html && wait $SERVER_PID"
   },
   "devDependencies": {
     "@babel/core": "^7.22.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-logql",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Grafana Loki logQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest",
     "build:test": "npm run build && npm run test",
     "pre-commit": "lint-staged",
-    "local": "python -m http.server & SERVER_PID=$! && trap 'kill $SERVER_PID' INT && open http://localhost:8000/tools/tree-viz.local.html && wait $SERVER_PID"
+    "local": "python3 -m http.server & SERVER_PID=$! && trap 'kill $SERVER_PID' INT && open http://localhost:8000/tools/tree-viz.local.html && wait $SERVER_PID"
   },
   "devDependencies": {
     "@babel/core": "^7.22.8",

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -450,32 +450,21 @@ ConvOp {
   
   @precedence { Duration, Bytes, Number }
 
+  // only accept `B, kB, MB, GB, TB, PB, KB, KiB, MiB, GiB, TiB, PiB`
+  // https://github.com/grafana/loki/blob/main/pkg/logql/syntax/lex.go#L382
   Bytes {
-    ( float "b" ) |
-    ( float "kib" ) |
-    ( float "Kib" ) |
-    ( float "kb" ) |
+    ( float "B" ) |   
     ( float "KB" ) |
-    ( float "mib" ) |
-    ( float "Mib" ) |
-    ( float "mb" ) |
+    ( float "KiB" ) |
+    ( float "kB" ) |
     ( float "MB" ) |
-    ( float "gib" ) |
-    ( float "Gib" ) |
-    ( float "gb" ) |
     ( float "GB" ) |
-    ( float "tib" ) |
-    ( float "Tib" ) |
-    ( float "tb" ) |
     ( float "TB" ) |
-    ( float "pib" ) |
-    ( float "Pib" ) |
-    ( float "pb" ) |
     ( float "PB" ) |
-    ( float "eib" ) |
-    ( float "Eib" ) |
-    ( float "eb" ) |
-    ( float "EB" ) 
+    ( float "MiB" ) |
+    ( float "GiB" ) |
+    ( float "TiB" ) |
+    ( float "PiB" )
   }
 
   // Operator

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -409,6 +409,7 @@ ConvOp {
 
 @tokens {
   whitespace { std.whitespace+ }
+  float { std.digit+ ("." std.digit+)? }
   LineComment { "#" ![\n]* }
 
   String {
@@ -434,43 +435,43 @@ ConvOp {
   Duration {
     // Each line below is just the same regex repeated over and over, but each time with one of the units made non-optional,
     // to ensure that at least one <number>+<unit> pair is provided and an empty string is not recognized as a valid duration.
-    ( ( std.digit+ "y" ) ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" )? ( std.digit+ "s" )? ( std.digit+ "ms" )? ) |
-    ( ( std.digit+ "y" )? ( std.digit+ "w" ) ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" )? ( std.digit+ "s" )? ( std.digit+ "ms" )? ) |
-    ( ( std.digit+ "y" )? ( std.digit+ "w" )? ( std.digit+ "d" ) ( std.digit+ "h" )? ( std.digit+ "m" )? ( std.digit+ "s" )? ( std.digit+ "ms" )? ) |
-    ( ( std.digit+ "y" )? ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" ) ( std.digit+ "m" )? ( std.digit+ "s" )? ( std.digit+ "ms" )? ) |
-    ( ( std.digit+ "y" )? ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" ) ( std.digit+ "s" )? ( std.digit+ "ms" )? ) |
-    ( ( std.digit+ "y" )? ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" )? ( std.digit+ "s" ) ( std.digit+ "ms" )? ) |
-    ( ( std.digit+ "y" )? ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" )? ( std.digit+ "s" )? ( std.digit+ "ms" ) )
+    ( ( float "y" ) ( float "w" )? ( float "d" )? ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" )? ) |
+    ( ( float "y" )? ( float "w" ) ( float "d" )? ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" )? ) |
+    ( ( float "y" )? ( float "w" )? ( float "d" ) ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" )? ) |
+    ( ( float "y" )? ( float "w" )? ( float "d" )? ( float "h" ) ( float "m" )? ( float "s" )? ( float "ms" )? ) |
+    ( ( float "y" )? ( float "w" )? ( float "d" )? ( float "h" )? ( float "m" ) ( float "s" )? ( float "ms" )? ) |
+    ( ( float "y" )? ( float "w" )? ( float "d" )? ( float "h" )? ( float "m" )? ( float "s" ) ( float "ms" )? ) |
+    ( ( float "y" )? ( float "w" )? ( float "d" )? ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" ) )
   }
   
   @precedence { Duration, Bytes, Number }
 
   Bytes {
-    ( std.digit+ "b" ) |
-    ( std.digit+ "kib" ) |
-    ( std.digit+ "Kib" ) |
-    ( std.digit+ "kb" ) |
-    ( std.digit+ "KB" ) |
-    ( std.digit+ "mib" ) |
-    ( std.digit+ "Mib" ) |
-    ( std.digit+ "mb" ) |
-    ( std.digit+ "MB" ) |
-    ( std.digit+ "gib" ) |
-    ( std.digit+ "Gib" ) |
-    ( std.digit+ "gb" ) |
-    ( std.digit+ "GB" ) |
-    ( std.digit+ "tib" ) |
-    ( std.digit+ "Tib" ) |
-    ( std.digit+ "tb" ) |
-    ( std.digit+ "TB" ) |
-    ( std.digit+ "pib" ) |
-    ( std.digit+ "Pib" ) |
-    ( std.digit+ "pb" ) |
-    ( std.digit+ "PB" ) |
-    ( std.digit+ "eib" ) |
-    ( std.digit+ "Eib" ) |
-    ( std.digit+ "eb" ) |
-    ( std.digit+ "EB" ) 
+    ( float "b" ) |
+    ( float "kib" ) |
+    ( float "Kib" ) |
+    ( float "kb" ) |
+    ( float "KB" ) |
+    ( float "mib" ) |
+    ( float "Mib" ) |
+    ( float "mb" ) |
+    ( float "MB" ) |
+    ( float "gib" ) |
+    ( float "Gib" ) |
+    ( float "gb" ) |
+    ( float "GB" ) |
+    ( float "tib" ) |
+    ( float "Tib" ) |
+    ( float "tb" ) |
+    ( float "TB" ) |
+    ( float "pib" ) |
+    ( float "Pib" ) |
+    ( float "pb" ) |
+    ( float "PB" ) |
+    ( float "eib" ) |
+    ( float "Eib" ) |
+    ( float "eb" ) |
+    ( float "EB" ) 
   }
 
   // Operator

--- a/src/logql.grammar
+++ b/src/logql.grammar
@@ -409,6 +409,7 @@ ConvOp {
 
 @tokens {
   whitespace { std.whitespace+ }
+  int { std.digit+ }
   float { std.digit+ ("." std.digit+)? }
   LineComment { "#" ![\n]* }
 
@@ -431,17 +432,20 @@ ConvOp {
   }
 
     LabelName { (std.asciiLetter | "_") (std.asciiLetter | std.digit | "_")* }
-  
   Duration {
     // Each line below is just the same regex repeated over and over, but each time with one of the units made non-optional,
     // to ensure that at least one <number>+<unit> pair is provided and an empty string is not recognized as a valid duration.
-    ( ( float "y" ) ( float "w" )? ( float "d" )? ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" )? ) |
-    ( ( float "y" )? ( float "w" ) ( float "d" )? ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" )? ) |
-    ( ( float "y" )? ( float "w" )? ( float "d" ) ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" )? ) |
-    ( ( float "y" )? ( float "w" )? ( float "d" )? ( float "h" ) ( float "m" )? ( float "s" )? ( float "ms" )? ) |
-    ( ( float "y" )? ( float "w" )? ( float "d" )? ( float "h" )? ( float "m" ) ( float "s" )? ( float "ms" )? ) |
-    ( ( float "y" )? ( float "w" )? ( float "d" )? ( float "h" )? ( float "m" )? ( float "s" ) ( float "ms" )? ) |
-    ( ( float "y" )? ( float "w" )? ( float "d" )? ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" ) )
+    Sub? (
+      ( ( int "y" ) ( int "w" )? ( int "d" )? ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" )? ( float "µs" | float "us" )? ( float "ns" )? ) |
+      ( ( int "y" )? ( int "w" ) ( int "d" )? ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" )? ( float "µs" | float "us" )? ( float "ns" )? ) |
+      ( ( int "y" )? ( int "w" )? ( int "d" ) ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" )? ( float "µs" | float "us" )? ( float "ns" )? ) |
+      ( ( int "y" )? ( int "w" )? ( int "d" )? ( float "h" ) ( float "m" )? ( float "s" )? ( float "ms" )? ( float "µs" | float "us" )? ( float "ns" )? ) |
+      ( ( int "y" )? ( int "w" )? ( int "d" )? ( float "h" )? ( float "m" ) ( float "s" )? ( float "ms" )? ( float "µs" | float "us" )? ( float "ns" )? ) |
+      ( ( int "y" )? ( int "w" )? ( int "d" )? ( float "h" )? ( float "m" )? ( float "s" ) ( float "ms" )? ( float "µs" | float "us" )? ( float "ns" )? ) |
+      ( ( int "y" )? ( int "w" )? ( int "d" )? ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" ) ( float "µs" | float "us" )? ( float "ns" )? ) |
+      ( ( int "y" )? ( int "w" )? ( int "d" )? ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" )? ( float "µs" | float "us" ) ( float "ns" )? ) |
+      ( ( int "y" )? ( int "w" )? ( int "d" )? ( float "h" )? ( float "m" )? ( float "s" )? ( float "ms" )? ( float "µs" | float "us" )? ( float "ns" ) ) 
+    )
   }
   
   @precedence { Duration, Bytes, Number }

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -270,6 +270,14 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 
 LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(Pipe, LogfmtParser(Logfmt))), PipelineStage(Pipe, LabelFilter(LabelFilter(UnitFilter(DurationFilter(Identifier, Gtr, Duration))), And, LabelFilter(UnitFilter(BytesFilter(Identifier, Gtr, Bytes)))))))))
 
+# Log query with duration and bytes as floats
+
+{job="mysql"} | logfmt | duration > 1.5m and bytes_consumed > 20.2MB
+
+==>
+
+LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineStage(Pipe, LogfmtParser(Logfmt))), PipelineStage(Pipe, LabelFilter(LabelFilter(UnitFilter(DurationFilter(Identifier, Gtr, Duration))), And, LabelFilter(UnitFilter(BytesFilter(Identifier, Gtr, Bytes)))))))))
+
 # Complex log query with duration and bytes
 
 {job="mysql"} | logfmt | duration >= 20ms or (method="GET" and size <= 20KB)

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -575,3 +575,43 @@ LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), Pipeline
 ==>
 
 LogQL(Expr(LogExpr(Selector(Matchers(Matcher(Identifier, Eq, String))), PipelineExpr(PipelineExpr(PipelineExpr(PipelineExpr(PipelineExpr(PipelineExpr(PipelineExpr(PipelineStage(Pipe, LogfmtParser(Logfmt))), PipelineStage(Pipe, LabelFilter(NumberFilter(Identifier, Gtr, LiteralExpr(Sub, Number))))), PipelineStage(Pipe, LabelFilter(NumberFilter(Identifier, Gte, LiteralExpr(Sub, Number))))), PipelineStage(Pipe, LabelFilter(NumberFilter(Identifier, Lss, LiteralExpr(Sub, Number))))), PipelineStage(Pipe, LabelFilter(NumberFilter(Identifier, Lte, LiteralExpr(Sub, Number))))), PipelineStage(Pipe, LabelFilter(NumberFilter(Identifier, Neq, LiteralExpr(Sub, Number))))), PipelineStage(Pipe, LabelFilter(NumberFilter(Identifier, Eql, LiteralExpr(Sub, Number))))))))
+
+# 5y2w3d4h5m6s succeeds
+
+5y2w3d4h5m6s
+
+==>
+
+LogQL(⚠(Duration))
+
+# 2w3y errors because week before year
+
+2w3y
+
+==>
+
+LogQL(⚠(Duration), ⚠(Duration))
+
+# 5.5y
+
+5.5y
+
+==>
+
+LogQL(Expr(MetricExpr(LiteralExpr(Number))), ⚠(Identifier))
+
+# 2.5h
+
+2.5h
+
+==>
+
+LogQL(⚠(Duration))
+
+# -2.5h
+
+-2.5h
+
+==>
+
+LogQL(⚠(Duration))

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -615,3 +615,43 @@ LogQL(⚠(Duration))
 ==>
 
 LogQL(⚠(Duration))
+
+# 20KB
+
+20KB
+
+==>
+
+LogQL(⚠(Bytes))
+
+# 20kb does parse as Bytes
+
+20kb
+
+==>
+
+LogQL(Expr(MetricExpr(LiteralExpr(Number))), ⚠(Identifier))
+
+# 20MB
+
+20MB
+
+==>
+
+LogQL(⚠(Bytes))
+
+# 20.5MB
+
+20.5MB 
+
+==>
+
+LogQL(⚠(Bytes))
+
+# -20.5MB
+
+-20.5MB 
+
+==>
+
+LogQL(Expr(MetricExpr(LiteralExpr(Sub, ⚠(Bytes)))))

--- a/tools/tree-viz.local.html
+++ b/tools/tree-viz.local.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/d3@6.7.0/dist/d3.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@hpcc-js/wasm@1.12.8/dist/index.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/d3-graphviz@4.1.0/build/d3-graphviz.min.js"></script>
+
+    <script type="importmap">
+      {
+        "imports": {
+          "@grafana/lezer-logql": "http://localhost:8000/dist/index.es.js",
+          "@lezer/lr": "https://cdn.jsdelivr.net/npm/@lezer/lr@1.0.0/dist/index.js",
+          "@lezer/common": "https://cdn.jsdelivr.net/npm/@lezer/common@1.0.0/dist/index.js"
+        }
+      }
+    </script>
+
+    <style>
+      #out > svg {
+        width: 100%;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <textarea style="width: 100%; resize: vertical" id="in" type="text">count_over_time({level="info"}[10s])</textarea>
+    <div id="cursor-pos"></div>
+    <div id="out"></div>
+    <script type="module">
+      import('@grafana/lezer-logql').then(
+        (lezerLogQL) => {
+          const inElem = document.querySelector('#in');
+          const cursorPosElem = document.querySelector('#cursor-pos');
+
+          let currentlyVisualizedText = '';
+          let currentlyVisualizedPos = 0;
+
+          const graphViz = d3.select('#out').graphviz();
+
+          inElem.focus();
+          inElem.setSelectionRange(25, 25);
+
+          function getNodeText(node) {
+            const prefix = node.type.isError ? 'ERROR' : node.name;
+            return `${prefix}_${node.index}__${node.from}_${node.to}`;
+          }
+
+          function getGraphLine(node) {
+            const nodeText = getNodeText(node);
+            if (node.parent != null) {
+              const parentText = getNodeText(node.parent);
+              return `${parentText}->${nodeText}`;
+            }
+          }
+
+          function render() {
+            const text = inElem.value;
+            const pos = inElem.selectionStart;
+
+            if (text === currentlyVisualizedText && pos === currentlyVisualizedPos) {
+              // no changes
+              return;
+            }
+
+            const tree = lezerLogQL.parser.parse(text);
+            const cur = tree.cursor(0);
+            const graphLines = [];
+            graphLines.push(getGraphLine(cur.node));
+            while (cur.next()) {
+              graphLines.push(getGraphLine(cur.node));
+            }
+
+            const posCur = tree.cursor(pos);
+
+            const nodeText = getNodeText(tree.cursor(pos));
+
+            const graphText = `digraph {
+              ${graphLines.join('\n')}
+              ${nodeText} [style=filled]
+            }`.trim();
+
+            graphViz.renderDot(graphText);
+
+            currentlyVisualizedText = text;
+            currentlyVisualizedPos = pos;
+
+            cursorPosElem.innerHTML = pos.toString();
+          }
+
+          render();
+
+          inElem.addEventListener('keyup', render);
+          inElem.addEventListener('click', render);
+        },
+        (error) => {
+          window.alert('module import failed. this requires a browser with import map support.');
+          console.error(error);
+        }
+      );
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
`10.2s` creates an Error even though it is valid:
![image](https://github.com/user-attachments/assets/21ab5889-d9b8-42d5-9540-0ea1cdbc5fec)

With this change, `10.2s` is correctly parsed as `Duration`:
![image](https://github.com/user-attachments/assets/ca1ae703-9471-4c01-b9d4-b4fd148be910)


Also adds a `local` script which can be used to start the tree-viz with the local build.

Fixes https://github.com/grafana/lezer-logql/issues/65