### PR TITLE
chore: add renovate package rules for grafana actions and peerDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,24 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>grafana/grafana-renovate-config//presets/data-sources/base"
+  ],
+  "packageRules": [
+    {
+      "description": "Disable minimum release age for Grafana owned GitHub Actions (grafana/*)",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "grafana/*"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "Don't pin peerDependencies, keep them as ranges and only widen when needed",
+      "matchDepTypes": [
+        "peerDependencies"
+      ],
+      "rangeStrategy": "widen"
+    }
   ]
 }


### PR DESCRIPTION
## What

Adds two `packageRules` to `renovate.json`:

- **Disable minimum release age for Grafana-owned GitHub Actions** (`grafana/*`) — these are trusted internally, so no need to wait out the release-age delay.
- **Keep `peerDependencies` as ranges** — use the `widen` range strategy instead of pinning, only widening when needed.

## Why

Speeds up adoption of internal Grafana action updates and avoids unnecessarily tightening peer dependency ranges for consumers.