### PR TITLE
docs: fix 404 link to LogQL grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lezer-logql
 
-LogQL lezer grammar based on https://github.com/grafana/loki/blob/main/pkg/logql/syntax/expr.y.
+LogQL lezer grammar based on https://github.com/grafana/loki/blob/main/pkg/logql/syntax/syntax.y.
 
 ## Installation
 


### PR DESCRIPTION
## What do these changes accomplish?

Fixes the broken (404) link to the LogQL grammar in the README.

## Why?

The README points at the grammar file in `grafana/loki`, but that file was renamed from `expr.y` to `syntax.y` (same directory, `pkg/logql/syntax/`), so the old link now 404s.
